### PR TITLE
Added limit and offset to handle unbounded loop issue

### DIFF
--- a/contracts/UsingTellor.sol
+++ b/contracts/UsingTellor.sol
@@ -32,7 +32,7 @@ contract UsingTellor is EIP2362Interface{
     /*Functions*/
     /*
     * @dev Allows the owner to set the address for the oracleID descriptors
-    * used by the ADO members for price key value pairs standarization 
+    * used by the ADO members for price key value pairs standarization
     * _oracleDescriptors is the address for the OracleIDDescriptions contract
     */
     function setOracleIDDescriptors(address _oracleDescriptors) external {
@@ -48,11 +48,11 @@ contract UsingTellor is EIP2362Interface{
     * @return bool true if it is able to retreive a value, the value, and the value's timestamp
     */
     function getCurrentValue(uint256 _requestId) public view returns (bool ifRetrieve, uint256 value, uint256 _timestampRetrieved) {
-        return getDataBefore(_requestId,now);
+        return getDataBefore(_requestId,now,1,0);
     }
 
     /**
-    * @dev Allows the user to get the latest value for the requestId specified using the 
+    * @dev Allows the user to get the latest value for the requestId specified using the
     * ADO specification for the standard inteface for price oracles
     * @param _bytesId is the ADO standarized bytes32 price/key value pair identifier
     * @return the timestamp, outcome or value/ and the status code (for retreived, null, etc...)
@@ -64,7 +64,7 @@ contract UsingTellor is EIP2362Interface{
             bool _didGet;
             uint256 _returnedValue;
             uint256 _timestampRetrieved;
-            (_didGet,_returnedValue,_timestampRetrieved) = getDataBefore(_id,now);
+            (_didGet,_returnedValue,_timestampRetrieved) = getDataBefore(_id,now,1,0);
             if(_didGet){
                 return (int(_returnedValue)*n,_timestampRetrieved, descriptions.getStatusFromTellorStatus(1));
             }
@@ -79,16 +79,18 @@ contract UsingTellor is EIP2362Interface{
     * @dev Allows the user to get the first value for the requestId after the specified timestamp
     * @param _requestId is the requestId to look up the value for
     * @param _timestamp after which to search for first verified value
+    * @param _limit a limit on the number of values to look at
+    * @param _offset the number of values to go back before looking for data values
     * @return bool true if it is able to retreive a value, the value, and the value's timestamp
     */
-    function getDataBefore(uint256 _requestId, uint256 _timestamp)
+    function getDataBefore(uint256 _requestId, uint256 _timestamp, uint256 _limit, uint256 _offset)
         public
         view
         returns (bool _ifRetrieve, uint256 _value, uint256 _timestampRetrieved)
     {
-        uint256 _count = _tellorm.getNewValueCountbyRequestId(_requestId);
+        uint256 _count = _tellorm.getNewValueCountbyRequestId(_requestId) - _offset;
         if (_count > 0) {
-            for (uint256 i = _count; i > 0; i--) {
+            for (uint256 i = _count; i > _count - _limit; i--) {
                 uint256 _time = _tellorm.getTimestampbyRequestIDandIndex(_requestId, i - 1);
                 if (_time > 0 && _time <= _timestamp && _tellorm.isInDispute(_requestId,_time) == false) {
                     return (true, _tellorm.retrieveData(_requestId, _time), _time);

--- a/test/testUsingTellor.js
+++ b/test/testUsingTellor.js
@@ -1,4 +1,4 @@
-/** 
+/**
 * This tests the oracle functions as they are called through usingTellor
 */
 const Web3 = require('web3');
@@ -12,7 +12,7 @@ const Mappings = artifacts.require("./OracleIDDescriptions");
 var bytes = "0xdfaa6f747f0f012e8f2069d6ecacff25f5cdf0258702051747439949737fc0b5";
 var api = "json(https://api.gdax.com/products/BTC-USD/ticker).price";
 var d = new Date()/1000;
-var startDate = Math.round(d + 86400);  
+var startDate = Math.round(d + 86400);
 
 advanceTime = (time) => {
     return new Promise((resolve, reject) => {
@@ -73,15 +73,15 @@ contract('UsingTellor Tests', function(accounts) {
         assert(vars[1]> 0 , "timestamp works")
         assert(vars[2] == 200, "Get status should work")
     })
-    it("Test getDataBefore", async function(){  
+    it("Test getDataBefore", async function(){
         for(var i = 0;i <=4 ;i++){
           await web3.eth.sendTransaction({to: oracle.address,from:accounts[i],gas:4000000,data:oracle2.methods.submitMiningSolution("nonce",1, 1200).encodeABI()})
          }
-        let vars = await usingTellor.getDataBefore.call(1,startDate);
+        let vars = await usingTellor.getDataBefore.call(1,startDate,1,0)
         assert(vars[0] == true, "ifRetreive is not true")
         assert(vars[1] == 1200, "Get last value should work")
     })
-    it("Test -- most recent", async function(){   
+    it("Test -- most recent", async function(){
         for(var i = 0;i <=4 ;i++){
           await web3.eth.sendTransaction({to: oracle.address,from:accounts[i],gas:4000000,data:oracle2.methods.submitMiningSolution("nonce",1, 120).encodeABI()})
         }
@@ -90,7 +90,7 @@ contract('UsingTellor Tests', function(accounts) {
         for(var i = 0;i <=4 ;i++){
           await web3.eth.sendTransaction({to: oracle.address,from:accounts[i],gas:4000000,data:oracle2.methods.submitMiningSolution("nonce",1, 1200).encodeABI()})
         }
-        let vars = await usingTellor.getDataBefore.call(1,startDate);
+        let vars = await usingTellor.getDataBefore.call(1,startDate,1,0)
         assert(vars[0] == true, "ifRetreive is not true")
         assert(vars[1] == 1200, "Get last value should work")
         vars = await usingTellor.getCurrentValue.call(1);
@@ -98,7 +98,7 @@ contract('UsingTellor Tests', function(accounts) {
         assert(vars[1] == 1200, "Get last value should work (cv)")
     })
     it("Test three getters with no values", async function(){
-        let vars = await usingTellor.getDataBefore.call(1,startDate);
+        let vars = await usingTellor.getDataBefore.call(1,startDate,1,0)
         assert(vars[0] == false, "ifRetreive is not true")
         assert(vars[1] == 0, "Get last value should work")
         assert(vars[2] == 0, "timestamp should be 0")
@@ -121,11 +121,11 @@ contract('UsingTellor Tests', function(accounts) {
         }
         let vars = await usingTellor.getCurrentValue.call(1)
         await web3.eth.sendTransaction({to: oracle.address,from:accounts[i],gas:4000000,data:oracle2.methods.beginDispute(1,vars[2]-0,2).encodeABI()})
-        vars = await usingTellor.getDataBefore.call(1,startDate);
+        vars = await usingTellor.getDataBefore.call(1,startDate,2,0)
         assert(vars[0] == true, "ifRetreive is not true")
         assert(vars[1] == 120, "Get last value should work")
     })
-    it("Test isInDispute in Tellor getter non 2 index", async function(){   
+    it("Test isInDispute in Tellor getter non 2 index", async function(){
         for(var i = 0;i <=4 ;i++){
           await web3.eth.sendTransaction({to: oracle.address,from:accounts[i],gas:4000000,data:oracle2.methods.submitMiningSolution("nonce",1, 120).encodeABI()})
         }


### PR DESCRIPTION
I tried to get some tests for this but unfortunately I couldn't reproduce it with Ganache, maybe it would work using geth. But, I did test this on Rinkeby in my smart contract and it resolves the unbounded loop issue of `getCurrentValue`.