### PR TITLE
Get data

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,140 @@ Use this package to install the Tellor User Contracts to test the implementation
 
 Once installed this will allow your contracts to inherit the functions from the Tellor UserTellor. 
 
+
+#### How to Use
+Just Inherit the UsingTellor contract, passing the Tellor address as a constructor argument: 
+
+Here's an example
+```solidity 
+contract BtcPriceContract is UsingTellor {
+
+  //This Contract now have access to all functions on UsingTellor
+
+  uint256 btcPrice;
+  uint256 btcRequetId = 2;
+
+  constructor(address payable _tellorAddress) UsingTellor(_tellorAddress) public {}
+
+  function setBtcPrice() public {
+    bool _didGet;
+    uint _timestamp;
+    uint _value;
+
+    (_didGet, btcPrice, _timestamp) = getCurrentValue(btcRequetId);
+  }
+}
+```
+##### Addresses:
+Mainnet: `0x0Ba45A8b5d5575935B8158a88C631E9F9C95a2e5`
+Rinkeby: `0xFe41Cb708CD98C5B20423433309E55b53F79134a`
+Test: Use the MockTellor address
+
+
+#### Available Tellor functions:
+
+Children contracts have access to the following functions:
+
+```solidity
+    /**
+    * @dev Retreive value from oracle based on requestId/timestamp
+    * @param _requestId being requested
+    * @param _timestamp to retreive data/value from
+    * @return uint value for requestId/timestamp submitted
+    */
+    function retrieveData(uint256 _requestId, uint256 _timestamp) public view returns(uint256);
+
+    /**
+    * @dev Gets if the mined value for the specified requestId/_timestamp is currently under dispute
+    * @param _requestId to looku p
+    * @param _timestamp is the timestamp to look up miners for
+    * @return bool true if requestId/timestamp is under dispute
+    */
+    function isInDispute(uint256 _requestId, uint256 _timestamp) public view returns(bool);
+
+    /**
+    * @dev Counts the number of values that have been submited for the request
+    * @param _requestId the requestId to look up
+    * @return uint count of the number of values received for the requestId
+    */
+    function getNewValueCountbyRequestId(uint256 _requestId) public view returns(uint);
+
+    /**
+    * @dev Gets the timestamp for the value based on their index
+    * @param _requestId is the requestId to look up
+    * @param _index is the value index to look up
+    * @return uint timestamp
+    */
+    function getTimestampbyRequestIDandIndex(uint256 _requestId, uint256 _index) public view returns(uint256);
+
+    /**
+    * @dev Allows the user to get the latest value for the requestId specified
+    * @param _requestId is the requestId to look up the value for
+    * @return bool true if it is able to retreive a value, the value, and the value's timestamp
+    */
+    function getCurrentValue(uint256 _requestId) public view returns (bool ifRetrieve, uint256 value, uint256 _timestampRetrieved);
+
+    /**
+    * @dev Allows the user to get the first value for the requestId before the specified timestamp
+    * @param _requestId is the requestId to look up the value for
+    * @param _timestamp before which to search for first verified value
+    * @param _limit a limit on the number of values to look at
+    * @param _offset the number of values to go back before looking for data values
+    * @return bool true if it is able to retreive a value, the value, and the value's timestamp
+    */
+    function getDataBefore(uint256 _requestId, uint256 _timestamp, uint256 _limit, uint256 _offset)
+        public
+        view
+        returns (bool _ifRetrieve, uint256 _value, uint256 _timestampRetrieved);
+
+```
+
+
+#### Mock Tellor:
+
+For ease of use, the  `UsingTellor`  repo provides a MockTellor system for easier integration. This mock version contains a few helper functions:
+
+```solidity
+    /**
+    * @dev The constructor allows for arbitrary balances on specified addresses;
+    * @param _initialBalances The addresses that will have tokens
+    * @param _intialAmounts How much TRB each address gets
+    */
+    constructor(address[] memory _initialBalances, uint256[] memory _intialAmounts) public;
+    
+
+    /**
+    * @dev A mock function to submit a value to be read withoun miners needed
+    * @param _requestId The tellorId to associate the value to
+    * @param _value the value for the requestId
+    */
+    function submitValue(uint256 _requestId,uint256 _value) external;
+    
+
+    /**
+    * @dev A mock function to create a dispute
+    * @param _requestId The tellorId to be disputed
+    * @param _timestamp the timestamp that indentifies for the value
+    */
+    function disputeValue(uint256 _requestId, uint256 _timestamp) external;
+
+    /**
+    * @dev A mock function to mint tokens
+    * @param _holder The destination address 
+    * @param _value the amount to be minted
+    */
+    function mint(address _holder, uint256 _value) public;
+
+    /**
+    * @dev A mock function to trasnfer tokens on behalf of any address, withou needing an approval
+    * @param _from The origin address
+    * @param _to The destination address 
+    * @param _value the amount to be transferred
+    */
+    function transferFrom(address _from, address _to, uint256 _amount) public returns(bool);
+
+```
+
 # Test
 Open two Git Bash terminals. 
 
@@ -22,6 +156,7 @@ ganache-cli
 On the second terminal run this code:
 ```bash
 clone https://github.com/tellor-io/usingtellor
+npm install
 truffle compile
 truffle test
 ```

--- a/contracts/UsingTellor.sol
+++ b/contracts/UsingTellor.sol
@@ -70,35 +70,69 @@ contract UsingTellor{
         return (false, 0 , _time);
     }
     
+    function getIndexForDataBefore(uint _requestId, uint256 _timestamp) public view returns (bool found, uint256 index){
+        uint256 _count = tellor.getNewValueCountbyRequestId(_requestId);   
+        if (_count > 0) {
+            uint middle;
+            uint start = 0;
+            uint end = _count - 1;
+            uint _time;
+
+            //Checking Boundaries to short-circuit the algorithm
+            _time = tellor.getTimestampbyRequestIDandIndex(_requestId, start);
+            if(_time >= _timestamp) return (false, 0);
+            _time = tellor.getTimestampbyRequestIDandIndex(_requestId, end);
+            if(_time < _timestamp) return (true, end);
+
+            //Since the value is within our boundaries, do a binary search
+            while(true) {
+                middle = (end - start) / 2 + 1 + start;
+                _time = tellor.getTimestampbyRequestIDandIndex(_requestId, middle);
+                if(_time < _timestamp){
+                    //get imeadiate next value
+                    uint _nextTime = tellor.getTimestampbyRequestIDandIndex(_requestId, middle + 1);
+                    if(_nextTime >= _timestamp){
+                        //_time is correct
+                        return (true, middle);
+                    } else  {
+                        //look from middle + 1(next value) to end
+                        start = middle + 1;
+                    }
+                } else {
+                    uint _prevTime = tellor.getTimestampbyRequestIDandIndex(_requestId, middle - 1);
+                    if(_prevTime < _timestamp){
+                        // _prevtime is correct
+                        return(true, middle - 1);
+                    } else {
+                        //look from start to middle -1(prev value)
+                        end = middle -1;
+                    }
+                }
+                //We couldn't found a value 
+                //if(middle - 1 == start || middle == _count) return (false, 0);
+            }
+        }
+        return (false, 0);
+    }
+
+
     /**
     * @dev Allows the user to get the first value for the requestId before the specified timestamp
     * @param _requestId is the requestId to look up the value for
     * @param _timestamp before which to search for first verified value
-    * @param _limit a limit on the number of values to look at
-    * @param _offset the number of values to go back before looking for data values
     * @return bool true if it is able to retreive a value, the value, and the value's timestamp
     */
-    function getDataBefore(uint256 _requestId, uint256 _timestamp, uint256 _limit, uint256 _offset)
+    function getDataBefore(uint256 _requestId, uint256 _timestamp)
         public
-        view
         returns (bool _ifRetrieve, uint256 _value, uint256 _timestampRetrieved)
     {
-        uint256 _count = tellor.getNewValueCountbyRequestId(_requestId);
-        if (_count > 0) {
-            for (uint256 i = _count - _offset; i < _count -_offset + _limit; i++) {
-                uint256 _time = tellor.getTimestampbyRequestIDandIndex(_requestId, i - 1);
-                if(_value > 0 && _time > _timestamp){
-                    return(true, _value, _timestampRetrieved);
-                }
-                else if (_time > 0 && _time <= _timestamp && tellor.isInDispute(_requestId,_time) == false) {
-                    _value = tellor.retrieveData(_requestId, _time);
-                    _timestampRetrieved = _time;
-                    if(i == _count){
-                        return(true, _value, _timestampRetrieved);
-                    }
-                }
-            }
-        }
+        
+        (bool _found, uint _index) = getIndexForDataBefore(_requestId,_timestamp);
+        if(!_found) return (false, 0, 0);
+        uint256 _time = tellor.getTimestampbyRequestIDandIndex(_requestId, _index);
+        _value = tellor.retrieveData(_requestId, _time);
+        //If value is diputed it'll return zero
+        if (_value > 0) return (true, _value, _time);
         return (false, 0, 0);
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usingtellor",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "truffle-config.js",
   "directories": {
     "test": "test"

--- a/test/BenchUsingTellor.sol
+++ b/test/BenchUsingTellor.sol
@@ -1,0 +1,18 @@
+pragma solidity 0.5.16;
+
+import "../contracts/UsingTellor.sol";
+
+/**
+* @title UserContract
+* This contracts creates for easy integration to the Tellor System
+* by allowing smart contracts to read data off Tellor
+*/
+contract BenchUsingTellor is UsingTellor{
+
+    constructor(address payable _tellor) UsingTellor(_tellor) public {
+
+    }
+    function wrapper(uint256 _requestId, uint256 _timestamp) public {
+        getDataBefore(_requestId, _timestamp);
+    }
+}

--- a/test/TellorMockTellor.js
+++ b/test/TellorMockTellor.js
@@ -1,6 +1,94 @@
 const MockTellor = artifacts.require("MockTellor.sol");
 const UsingTellor = artifacts.require("UsingTellor.sol");
+const BenchUsingTellor = artifacts.require("BenchUsingTellor.sol");
 
+advanceTime = (time) => {
+  return new Promise((resolve, reject) => {
+    web3.currentProvider.send(
+      {
+        jsonrpc: "2.0",
+        method: "evm_increaseTime",
+        params: [time],
+        id: new Date().getTime(),
+      },
+      (err, result) => {
+        if (err) {
+          return reject(err);
+        }
+        return resolve(result);
+      }
+    );
+  });
+};
+
+const getIndexForDataBefore = async (_requestId, _timestamp, tellor) => {
+  let _countB = await tellor.getNewValueCountbyRequestId(_requestId);
+  // console.log("STARTING", _timestamp);
+  let _count = _countB.toNumber();
+  if (_count > 0) {
+    let start = 0;
+    let end = _count - 1;
+    let middle;
+    while (true) {
+      middle = Math.floor((end - start) / 2) + 1 + start;
+      // console.log("I: ", i);
+      // console.log("start", start);
+      // console.log("middle", middle);
+      // console.log("end", end);
+      let _timeB = await tellor.getTimestampbyRequestIDandIndex(
+        _requestId,
+        middle
+      );
+      let _timeS = await tellor.getTimestampbyRequestIDandIndex(
+        _requestId,
+        start
+      );
+      let _timeE = await tellor.getTimestampbyRequestIDandIndex(
+        _requestId,
+        end
+      );
+      if (_timeE.toNumber() < _timestamp) return [true, end];
+      if (_timeS.toNumber() >= _timestamp) return [false, 0];
+      let _time = _timeB.toNumber();
+      // console.log("time:", _time);
+
+      if (_time < _timestamp) {
+        // console.log("Time is smaller than timestamp");
+        //get imeadiate next value
+        let _nextTimeB = await tellor.getTimestampbyRequestIDandIndex(
+          _requestId,
+          middle + 1
+        );
+        let _nextTime = _nextTimeB.toNumber();
+        // console.log("nextTime", _nextTime);
+        if (_nextTime >= _timestamp) {
+          // console.log("returning inside nextTime", true, middle);
+          //_time is correct
+          return [true, middle];
+        } else {
+          //look from middle + 1 to count
+          start = middle + 1;
+        }
+      } else {
+        // console.log("Time is bigger than timestamp");
+        let _prevTimeB = await tellor.getTimestampbyRequestIDandIndex(
+          _requestId,
+          middle - 1
+        );
+        let _prevTime = _prevTimeB.toNumber();
+        if (_prevTime < _timestamp) {
+          // _prevtime is correct
+          // console.log("returning inside prevTime", true, middle - 1);
+          return [true, middle - 1];
+        } else {
+          //look from middle -1 to 0
+          end = middle - 1;
+        }
+      }
+    }
+  }
+  return [false, 0];
+};
 contract("Mock Tellor", function(accounts) {
   let oracle;
   let balances = [];
@@ -40,5 +128,70 @@ contract("Mock Tellor", function(accounts) {
     await oracle.submitValue(requestId, val);
     count = await oracle.getNewValueCountbyRequestId(requestId);
     assert.isTrue(count.toString() == "1");
+  });
+});
+
+contract("Using Tellor", function(accounts) {
+  let oracle;
+  let usingTellor;
+  let balances = [];
+  for (var i = 0; i < accounts.length; i++) {
+    balances.push(web3.utils.toWei("7000", "ether"));
+  }
+  const val = "4000";
+  const requestId = 1;
+
+  beforeEach("Setup contract for each test", async function() {
+    //deploy old, request, update address, mine old challenge.
+    oracle = await MockTellor.new(accounts, balances);
+    usingTellor = await UsingTellor.new(oracle.address);
+  });
+
+  it("Can find IndexForDataBefore", async () => {
+    //add a bunch of times
+    for (let i = 0; i <= 20; i++) {
+      await oracle.submitValue(requestId, i + val);
+      await advanceTime(2);
+    }
+    // let am = await oracle.getNewValueCountbyRequestId(requestId);
+    let lowValue = await oracle.getTimestampbyRequestIDandIndex(requestId, 0);
+    let highValue = await oracle.getTimestampbyRequestIDandIndex(requestId, 20);
+    for (let i = lowValue.toNumber(); i <= highValue.toNumber() + 2; i++) {
+      // console.log("Cheking for timestamp ", i);
+      let idx = await usingTellor.getIndexForDataBefore(requestId, i);
+      let ref_idx = await getIndexForDataBefore(requestId, i, oracle);
+      // console.log(idx["0"], ref_idx[0], idx["1"].toNumber(), ref_idx[1]);
+      assert(idx["0"] == ref_idx[0]);
+      assert(idx["1"].toNumber() == ref_idx[1]);
+    }
+  });
+
+  it("Gas Value Test For GetDataBefore", async () => {
+    let bench = await BenchUsingTellor.new(oracle.address);
+    //add a bunch of times
+    for (let i = 0; i <= 100; i++) {
+      await oracle.submitValue(requestId, i + val);
+      await advanceTime(1);
+    }
+    // let am = await oracle.getNewValueCountbyRequestId(requestId);
+    let lowValue = await oracle.getTimestampbyRequestIDandIndex(requestId, 0);
+    let highValue = await oracle.getTimestampbyRequestIDandIndex(
+      requestId,
+      100
+    );
+
+    let worse = 0;
+    for (let i = lowValue.toNumber(); i <= highValue.toNumber() + 1; i++) {
+      // console.log(i);
+      let idx = await bench.wrapper(requestId, i);
+      let gas = idx.receipt.gasUsed;
+      if (gas > worse) {
+        worse = gas;
+      }
+    }
+    // console.log("Gas used for worse case scnerio: ", worse);
+
+    // I run with 10k values in the array and the gas spendig was:
+    //Gas used for worse case scnerio:  128033
   });
 });


### PR DESCRIPTION
Modified `getDataBefore` to only accept a requestId and a Timestamp, using binary search.

Tested in an array with 10k values and the worse case scenario search cost about 130k gas, so I left without any more protections, since we're pretty far from block gas limit.

I already updated the package version and I'm waiting to merge to master to publish the new version on npm, so I can update the SampleUsingTellor repo